### PR TITLE
Get base url from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ jupyter cad
 
 - A `jupyter-server` endpoint which is ready to compute the mesh upon client demand. This endpoint is defined using [an OpenAPI spec](https://github.com/jupytercad/jupytercad-salome/blob/main/jupytercad_salome/schema/openapi.yaml). Users are not bound to the provided jupyter-server endpoint, `JupyterCAD-Salome` can connect to any server implementing the OpenAPI spec.
 
+> [!NOTE]
+> To use `JupyterCAD-Salome` with a different Salome server, set the `SALOME_SERVER_BASE_URL` environment variable to your server address before starting `JupyterLab`.
+
 - A client plugin for JupyterCAD adding UI elements to interact with the mesh-generation endpoint. Whenever the user clicks on the toolbar button, they are prompted with a dialog to configure the API call:
 
 ![Meshing configuration](https://github.com/martinRenou/jupytercad-salome/assets/21197331/15b03e37-3716-4f82-b5bf-b99abed6c016)

--- a/jupytercad_salome/main.py
+++ b/jupytercad_salome/main.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
@@ -15,10 +16,11 @@ class RouteHandler(APIHandler):
         """Return the base url of the jupytercad salome server.
         Use ``None`` if it is the same JupyterLab server
         """
+        base_url_env = os.getenv("SALOME_SERVER_BASE_URL", None)
         self.finish(
             json.dumps(
                 {
-                    "backend_url": None,
+                    "backend_url": base_url_env,
                 }
             )
         )


### PR DESCRIPTION
Get the mesh-generation endpoint from `SALOME_SERVER_BASE_URL` env variable.

Closes #4 